### PR TITLE
Fix dedicated server crash with grindstone

### DIFF
--- a/common/src/main/java/com/ordana/spelunkery/events/ModEvents.java
+++ b/common/src/main/java/com/ordana/spelunkery/events/ModEvents.java
@@ -210,8 +210,11 @@ public class ModEvents {
                         if (!player.getAbilities().instabuild) stack.shrink(1);
                     }
                     else if (state.is(ModBlocks.DIAMOND_GRINDSTONE.get()) && state.getValue(ModBlockProperties.DEPLETION) == 3 && polishingRecipe.isRequiresDiamondGrindstone() || (polishingRecipe.isRequiresDiamondGrindstone() && !state.is(ModBlocks.DIAMOND_GRINDSTONE.get()))) {
-                        ParticleUtil.spawnParticlesOnBlockFaces(level, pos, ParticleTypes.SMOKE, UniformInt.of(3, 5), -0.05f, 0.05f, false);
-                        player.swing(hand);
+                        if (level.isClientSide()) {
+                            ParticleUtil.spawnParticlesOnBlockFaces(level, pos, ParticleTypes.SMOKE, UniformInt.of(3, 5), -0.05f, 0.05f, false);
+                            player.swing(hand);
+                        }
+
                         level.playSound(player, pos, SoundEvents.SHIELD_BREAK, SoundSource.BLOCKS, 0.5F, 0.0F);
                         return InteractionResult.sidedSuccess(level.isClientSide);
                     }


### PR DESCRIPTION
Closes #248.

On the dedicated server, using a grindstone would cause a crash. This is caused by Spelunkery using a client-only class from Moonlight API, `ParticleUtil`. When `ParticleUtil#spawnParticlesOnBlockFaces` is called, it proceeds to initialize all of the static fields within `ParticleUtil`, which then causes a crash due to Java being unable to locate the `ParticleRenderType` class.

By wrapping `ParticleUtil#spawnParticlesOnBlockFaces` with a `Level#isClientSide` if check, it avoids initializing the `ParticleUtil` class entirely. I have also included `Player#swing` into this check, following how `useGrindstone` also does it.