### PR TITLE
Fix passive sluice loot table name bug

### DIFF
--- a/common/src/main/java/com/ordana/spelunkery/blocks/ChannelSluiceBlock.java
+++ b/common/src/main/java/com/ordana/spelunkery/blocks/ChannelSluiceBlock.java
@@ -103,8 +103,7 @@ public class ChannelSluiceBlock extends ModBaseEntityBlock {
 
         if (!Objects.equals(fluidName, "empty")) {
 
-            if (fluidName.contains("flowing")) fluidName = fluidName.replace("flowing", "");
-            if (fluidName.contains("_")) fluidName = fluidName.replace("_", "");
+            if (fluidName.contains("flowing_")) fluidName = fluidName.replace("flowing_", "");
 
             var tablePath = Spelunkery.res("gameplay/sluice/" + fluidName + "/passive");
             var lootTable = Objects.requireNonNull(level.getServer()).getLootData().getLootTable(tablePath);


### PR DESCRIPTION
The code accidentally removed *all* underscores rather than just the one in the substring "flowing_".
(Technically I didn't test the change I made, but I *really* hope I didn't manage to mess it up somehow considering how trivial the change was and the fact that I compared it against existing code just to make sure I wasn't insane.)