### PR TITLE
Add grindstone disenchant config

### DIFF
--- a/common/src/main/java/com/ordana/spelunkery/configs/CommonConfigs.java
+++ b/common/src/main/java/com/ordana/spelunkery/configs/CommonConfigs.java
@@ -21,6 +21,7 @@ public class CommonConfigs {
     public static Supplier<Boolean> ENABLE_RAW_NUGGETS;
     public static Supplier<Boolean> ORE_STONE_DROPS;
     //public static Supplier<Boolean> ENABLE_GEM_SHARDS;
+    public static Supplier<Boolean> GRINDSTONE_DISENCHANTS_TOOLS;
 
     public static Supplier<Boolean> INCREASED_SLIME_SPAWN_RATE;
     public static Supplier<Boolean> SLIME_CAULDRONS;
@@ -77,6 +78,7 @@ public class CommonConfigs {
         PlatHelper.getPlatform().ifFabric(() -> {
             ORE_STONE_DROPS = builder.define("ores_drop_base_stone", false);
         });
+        GRINDSTONE_DISENCHANTS_TOOLS = builder.define("grindstone_disenchants_tools", true);
         builder.pop();
 
         builder.push("utilities");

--- a/common/src/main/java/com/ordana/spelunkery/events/ModEvents.java
+++ b/common/src/main/java/com/ordana/spelunkery/events/ModEvents.java
@@ -221,7 +221,7 @@ public class ModEvents {
         if (!state.is(Blocks.GRINDSTONE) && !state.is(ModBlocks.DIAMOND_GRINDSTONE.get())) return InteractionResult.PASS;
 
         //handle enchants
-        if (stack.isEnchanted()) {
+        if (stack.isEnchanted() && CommonConfigs.GRINDSTONE_DISENCHANTS_TOOLS.get()) {
             if (level instanceof ServerLevel serverLevel) ExperienceOrb.award(serverLevel, Vec3.atCenterOf(pos), getExperienceFromItem(stack, depleted));
             player.setItemInHand(hand, removeEnchants(stack, stack.getDamageValue(), depleted));
             return InteractionResult.SUCCESS;


### PR DESCRIPTION
Adds config option for whether crouch-clicking on a grindstone with an enchanted tool removes enchantments. I'm playing with [Overgeared](https://modrinth.com/mod/overgeared) which lets you repair tools by using them on the grindstone, and I would prefer not to lose my enchantments in the process.