### PR TITLE
Further fixes

### DIFF
--- a/common/src/main/java/com/ordana/spelunkery/blocks/TangleRootsBodyBlock.java
+++ b/common/src/main/java/com/ordana/spelunkery/blocks/TangleRootsBodyBlock.java
@@ -50,15 +50,7 @@ public class TangleRootsBodyBlock extends GrowingPlantBodyBlock implements Simpl
                         .setValue(WATERLOGGED, levelReader.getFluidState(blockPos).getType() == Fluids.WATER);
     }
 
-    public void tick(BlockState state, ServerLevel level, BlockPos pos, RandomSource random) {
-        BlockState blockState = state.setValue(TOP, this.isTop(level, pos));
-        if (!state.getValue(TOP) && !level.getBlockState(pos.above()).is(this)) {
-            level.destroyBlock(pos, true);
-        } else if (state != blockState) {
-            level.setBlock(pos, blockState, 3);
-        }
-    }
-
+    @Override
     public void onPlace(BlockState state, Level level, BlockPos pos, BlockState oldState, boolean isMoving) {
         if (!level.isClientSide) {
             level.scheduleTick(pos, this, 1);
@@ -70,6 +62,7 @@ public class TangleRootsBodyBlock extends GrowingPlantBodyBlock implements Simpl
         return simpleCodec(TangleRootsBodyBlock::new);
     }
 
+    @Override
     public BlockState updateShape(BlockState state, Direction direction, BlockState neighborState, LevelAccessor level, BlockPos currentPos, BlockPos neighborPos) {
         if (state.getValue(WATERLOGGED)) {
             level.scheduleTick(currentPos, Fluids.WATER, Fluids.WATER.getTickDelay(level));
@@ -81,14 +74,17 @@ public class TangleRootsBodyBlock extends GrowingPlantBodyBlock implements Simpl
         return super.updateShape(state, direction, neighborState, level, currentPos, neighborPos);
     }
 
+    @Override
     public FluidState getFluidState(BlockState state) {
         return state.getValue(WATERLOGGED) ? Fluids.WATER.getSource(false) : super.getFluidState(state);
     }
 
+    @Override
     protected GrowingPlantHeadBlock getHeadBlock() {
         return (GrowingPlantHeadBlock) ModBlocks.TANGLE_ROOTS.get();
     }
 
+    @Override
     protected void createBlockStateDefinition(StateDefinition.Builder<Block, BlockState> builder) {
         builder.add(WATERLOGGED, TOP);
     }

--- a/common/src/main/resources/data/c/tags/block/ores/coal.json
+++ b/common/src/main/resources/data/c/tags/block/ores/coal.json
@@ -1,0 +1,23 @@
+{
+  "replace": false,
+  "values": [
+    {
+      "id": "spelunkery:andesite_coal_ore",
+      "required": false
+    },
+    {
+      "id": "spelunkery:diorite_coal_ore",
+      "required": false
+    },
+    {
+      "id": "spelunkery:granite_coal_ore",
+      "required": false
+    },
+    {
+      "id": "spelunkery:tuff_coal_ore",
+      "required": false
+    },
+    "minecraft:deepslate_coal_ore",
+    "minecraft:coal_ore"
+  ]
+}

--- a/common/src/main/resources/data/c/tags/block/ores/copper.json
+++ b/common/src/main/resources/data/c/tags/block/ores/copper.json
@@ -1,0 +1,23 @@
+{
+  "replace": false,
+  "values": [
+    {
+      "id": "spelunkery:andesite_copper_ore",
+      "required": false
+    },
+    {
+      "id": "spelunkery:diorite_copper_ore",
+      "required": false
+    },
+    {
+      "id": "spelunkery:granite_copper_ore",
+      "required": false
+    },
+    {
+      "id": "spelunkery:tuff_copper_ore",
+      "required": false
+    },
+    "minecraft:deepslate_copper_ore",
+    "minecraft:copper_ore"
+  ]
+}

--- a/common/src/main/resources/data/c/tags/block/ores/diamond.json
+++ b/common/src/main/resources/data/c/tags/block/ores/diamond.json
@@ -1,0 +1,27 @@
+{
+  "replace": false,
+  "values": [
+    {
+      "id": "spelunkery:smooth_basalt_diamond_ore",
+      "required": false
+    },
+    {
+      "id": "spelunkery:andesite_diamond_ore",
+      "required": false
+    },
+    {
+      "id": "spelunkery:diorite_diamond_ore",
+      "required": false
+    },
+    {
+      "id": "spelunkery:granite_diamond_ore",
+      "required": false
+    },
+    {
+      "id": "spelunkery:tuff_diamond_ore",
+      "required": false
+    },
+    "minecraft:deepslate_diamond_ore",
+    "minecraft:diamond_ore"
+  ]
+}

--- a/common/src/main/resources/data/c/tags/block/ores/emerald.json
+++ b/common/src/main/resources/data/c/tags/block/ores/emerald.json
@@ -1,0 +1,23 @@
+{
+  "replace": false,
+  "values": [
+    {
+      "id": "spelunkery:andesite_emerald_ore",
+      "required": false
+    },
+    {
+      "id": "spelunkery:diorite_emerald_ore",
+      "required": false
+    },
+    {
+      "id": "spelunkery:granite_emerald_ore",
+      "required": false
+    },
+    {
+      "id": "spelunkery:tuff_emerald_ore",
+      "required": false
+    },
+    "minecraft:deepslate_emerald_ore",
+    "minecraft:emerald_ore"
+  ]
+}

--- a/common/src/main/resources/data/c/tags/block/ores/gold.json
+++ b/common/src/main/resources/data/c/tags/block/ores/gold.json
@@ -1,0 +1,23 @@
+{
+  "replace": false,
+  "values": [
+    {
+      "id": "spelunkery:andesite_gold_ore",
+      "required": false
+    },
+    {
+      "id": "spelunkery:diorite_gold_ore",
+      "required": false
+    },
+    {
+      "id": "spelunkery:granite_gold_ore",
+      "required": false
+    },
+    {
+      "id": "spelunkery:tuff_gold_ore",
+      "required": false
+    },
+    "minecraft:deepslate_gold_ore",
+    "minecraft:gold_ore"
+  ]
+}

--- a/common/src/main/resources/data/c/tags/block/ores/iron.json
+++ b/common/src/main/resources/data/c/tags/block/ores/iron.json
@@ -1,0 +1,23 @@
+{
+  "replace": false,
+  "values": [
+    {
+      "id": "spelunkery:andesite_iron_ore",
+      "required": false
+    },
+    {
+      "id": "spelunkery:diorite_iron_ore",
+      "required": false
+    },
+    {
+      "id": "spelunkery:granite_iron_ore",
+      "required": false
+    },
+    {
+      "id": "spelunkery:tuff_iron_ore",
+      "required": false
+    },
+    "minecraft:deepslate_iron_ore",
+    "minecraft:iron_ore"
+  ]
+}

--- a/common/src/main/resources/data/c/tags/block/ores/jade.json
+++ b/common/src/main/resources/data/c/tags/block/ores/jade.json
@@ -1,0 +1,21 @@
+{
+  "replace": false,
+  "values": [
+    {
+      "id": "spelunkery:granite_jade_ore",
+      "required": false
+    },
+    {
+      "id": "spelunkery:diorite_jade_ore",
+      "required": false
+    },
+    {
+      "id": "spelunkery:andesite_jade_ore",
+      "required": false
+    },
+    {
+      "id": "spelunkery:tuff_jade_ore",
+      "required": false
+    }
+  ]
+}

--- a/common/src/main/resources/data/c/tags/block/ores/lapis.json
+++ b/common/src/main/resources/data/c/tags/block/ores/lapis.json
@@ -1,0 +1,27 @@
+{
+  "replace": false,
+  "values": [
+    {
+      "id": "spelunkery:andesite_lapis_ore",
+      "required": false
+    },
+    {
+      "id": "spelunkery:diorite_lapis_ore",
+      "required": false
+    },
+    {
+      "id": "spelunkery:granite_lapis_ore",
+      "required": false
+    },
+    {
+      "id": "spelunkery:tuff_lapis_ore",
+      "required": false
+    },
+    {
+      "id": "spelunkery:sandstone_lapis_ore",
+      "required": false
+    },
+    "minecraft:deepslate_lapis_ore",
+    "minecraft:lapis_ore"
+  ]
+}

--- a/common/src/main/resources/data/c/tags/block/ores/lead.json
+++ b/common/src/main/resources/data/c/tags/block/ores/lead.json
@@ -1,0 +1,21 @@
+{
+  "replace": false,
+  "values": [
+    {
+      "id": "spelunkery:granite_lead_ore",
+      "required": false
+    },
+    {
+      "id": "spelunkery:diorite_lead_ore",
+      "required": false
+    },
+    {
+      "id": "spelunkery:andesite_lead_ore",
+      "required": false
+    },
+    {
+      "id": "spelunkery:tuff_lead_ore",
+      "required": false
+    }
+  ]
+}

--- a/common/src/main/resources/data/c/tags/block/ores/redstone.json
+++ b/common/src/main/resources/data/c/tags/block/ores/redstone.json
@@ -1,0 +1,27 @@
+{
+  "replace": false,
+  "values": [
+    {
+      "id": "spelunkery:andesite_redstone_ore",
+      "required": false
+    },
+    {
+      "id": "spelunkery:diorite_redstone_ore",
+      "required": false
+    },
+    {
+      "id": "spelunkery:granite_redstone_ore",
+      "required": false
+    },
+    {
+      "id": "spelunkery:tuff_redstone_ore",
+      "required": false
+    },
+    {
+      "id": "spelunkery:calcite_redstone_ore",
+      "required": false
+    },
+    "minecraft:deepslate_redstone_ore",
+    "minecraft:redstone_ore"
+  ]
+}

--- a/common/src/main/resources/data/c/tags/block/ores/silver.json
+++ b/common/src/main/resources/data/c/tags/block/ores/silver.json
@@ -1,0 +1,21 @@
+{
+  "replace": false,
+  "values": [
+    {
+      "id": "spelunkery:granite_silver_ore",
+      "required": false
+    },
+    {
+      "id": "spelunkery:diorite_silver_ore",
+      "required": false
+    },
+    {
+      "id": "spelunkery:andesite_silver_ore",
+      "required": false
+    },
+    {
+      "id": "spelunkery:tuff_silver_ore",
+      "required": false
+    }
+  ]
+}

--- a/common/src/main/resources/data/c/tags/block/ores/zinc.json
+++ b/common/src/main/resources/data/c/tags/block/ores/zinc.json
@@ -1,0 +1,21 @@
+{
+  "replace": false,
+  "values": [
+    {
+      "id": "spelunkery:granite_zinc_ore",
+      "required": false
+    },
+    {
+      "id": "spelunkery:diorite_zinc_ore",
+      "required": false
+    },
+    {
+      "id": "spelunkery:andesite_zinc_ore",
+      "required": false
+    },
+    {
+      "id": "spelunkery:tuff_zinc_ore",
+      "required": false
+    }
+  ]
+}

--- a/common/src/main/resources/data/spelunkery/loot_table/blocks/tangle_roots.json
+++ b/common/src/main/resources/data/spelunkery/loot_table/blocks/tangle_roots.json
@@ -16,22 +16,22 @@
                     {
                       "condition": "minecraft:match_tool",
                       "predicate": {
-                        "items": [
-                          "minecraft:shears"
-                        ]
+                        "items": "#c:tools/shear"
                       }
                     },
                     {
                       "condition": "minecraft:match_tool",
                       "predicate": {
-                        "enchantments": [
-                          {
-                            "enchantment": "minecraft:silk_touch",
-                            "levels": {
-                              "min": 1
+                        "predicates": {
+                          "minecraft:enchantments": [
+                            {
+                              "enchantments": "minecraft:silk_touch",
+                              "levels": {
+                                "min": 1
+                              }
                             }
-                          }
-                        ]
+                          ]
+                        }
                       }
                     }
                   ]

--- a/common/src/main/resources/data/spelunkery/loot_table/blocks/tangle_roots_block.json
+++ b/common/src/main/resources/data/spelunkery/loot_table/blocks/tangle_roots_block.json
@@ -16,22 +16,22 @@
                     {
                       "condition": "minecraft:match_tool",
                       "predicate": {
-                        "items": [
-                          "minecraft:shears"
-                        ]
+                        "items": "#c:tools/shear"
                       }
                     },
                     {
                       "condition": "minecraft:match_tool",
                       "predicate": {
-                        "enchantments": [
-                          {
-                            "enchantment": "minecraft:silk_touch",
-                            "levels": {
-                              "min": 1
+                        "predicates": {
+                          "minecraft:enchantments": [
+                            {
+                              "enchantments": "minecraft:silk_touch",
+                              "levels": {
+                                "min": 1
+                              }
                             }
-                          }
-                        ]
+                          ]
+                        }
                       }
                     }
                   ]

--- a/common/src/main/resources/data/spelunkery/loot_table/blocks/tangle_roots_plant.json
+++ b/common/src/main/resources/data/spelunkery/loot_table/blocks/tangle_roots_plant.json
@@ -16,22 +16,22 @@
                     {
                       "condition": "minecraft:match_tool",
                       "predicate": {
-                        "items": [
-                          "minecraft:shears"
-                        ]
+                        "items": "#c:tools/shear"
                       }
                     },
                     {
                       "condition": "minecraft:match_tool",
                       "predicate": {
-                        "enchantments": [
-                          {
-                            "enchantment": "minecraft:silk_touch",
-                            "levels": {
-                              "min": 1
+                        "predicates": {
+                          "minecraft:enchantments": [
+                            {
+                              "enchantments": "minecraft:silk_touch",
+                              "levels": {
+                                "min": 1
+                              }
                             }
-                          }
-                        ]
+                          ]
+                        }
                       }
                     }
                   ]

--- a/common/src/main/resources/data/spelunkery/overrides/loot_tables/sculk.json
+++ b/common/src/main/resources/data/spelunkery/overrides/loot_tables/sculk.json
@@ -40,9 +40,7 @@
                 {
                   "condition": "minecraft:match_tool",
                   "predicate": {
-                    "items": [
-                      "minecraft:shears"
-                    ]
+                    "items": "#c:tools/shear"
                   }
                 }
               ]

--- a/common/src/main/resources/data/spelunkery/overrides/loot_tables/sculk_vein.json
+++ b/common/src/main/resources/data/spelunkery/overrides/loot_tables/sculk_vein.json
@@ -122,9 +122,7 @@
                 {
                   "condition": "minecraft:match_tool",
                   "predicate": {
-                    "items": [
-                      "minecraft:shears"
-                    ]
+                    "items": "#c:tools/shear"
                   }
                 }
               ]


### PR DESCRIPTION
- Loot tables now properly require enchantments and use the conventional item tag for shears.
- Added tags for the conventional ore tags.
- Removed unnecessary ticking logic in tangle roots