### PR TITLE
Fix: SynchedEntityData registration leak in EggPlither causing Wither mod conflicts

### DIFF
--- a/common/src/main/java/com/ordana/spelunkery/entities/EggPlither.java
+++ b/common/src/main/java/com/ordana/spelunkery/entities/EggPlither.java
@@ -504,11 +504,11 @@ public class EggPlither extends WitherBoss implements PowerableMob, RangedAttack
     }
 
     static {
-        DATA_TARGET_A = SynchedEntityData.defineId(WitherBoss.class, EntityDataSerializers.INT);
-        DATA_TARGET_B = SynchedEntityData.defineId(WitherBoss.class, EntityDataSerializers.INT);
-        DATA_TARGET_C = SynchedEntityData.defineId(WitherBoss.class, EntityDataSerializers.INT);
+        DATA_TARGET_A = SynchedEntityData.defineId(EggPlither.class, EntityDataSerializers.INT);
+        DATA_TARGET_B = SynchedEntityData.defineId(EggPlither.class, EntityDataSerializers.INT);
+        DATA_TARGET_C = SynchedEntityData.defineId(EggPlither.class, EntityDataSerializers.INT);
         DATA_TARGETS = ImmutableList.of(DATA_TARGET_A, DATA_TARGET_B, DATA_TARGET_C);
-        DATA_ID_INV = SynchedEntityData.defineId(WitherBoss.class, EntityDataSerializers.INT);
+        DATA_ID_INV = SynchedEntityData.defineId(EggPlither.class, EntityDataSerializers.INT);
         LIVING_ENTITY_SELECTOR = (livingEntity) -> false;
         TARGETING_CONDITIONS = TargetingConditions.forCombat().range(20.0).selector(LIVING_ENTITY_SELECTOR);
     }


### PR DESCRIPTION
**Description of the issue**
In `EggPlither.java`, the `SynchedEntityData.defineId` calls in the static block incorrectly reference `WitherBoss.class` instead of `EggPlither.class`. 

This causes a registration leak where `EggPlither`'s custom entity data (like `DATA_TARGET_A`, `DATA_TARGET_B`, `DATA_ID_INV`) is injected directly into the vanilla `WitherBoss` synched data pool. 

**Impact**
When other mods (such as *Wither's Wrath*) attempt to register or read their own synched data for the vanilla Wither, the offset caused by this leak results in a critical server error: `java.lang.IllegalStateException: Entity class net.minecraft.world.entity.boss.wither.WitherBoss has not defined synched data value 20`. This suppresses the interaction thread and causes severe desync/ghost blocks for players when trying to summon the Wither.

**Fix**
Changed `WitherBoss.class` to `EggPlither.class` in the static block registering the `EntityDataAccessor` fields. This correctly isolates the synched data to the EggPlither entity.