### PR TITLE
Add more spelunkery features to relevant minecraft and common tags

### DIFF
--- a/common/src/main/resources/data/c/tags/block/ladders.json
+++ b/common/src/main/resources/data/c/tags/block/ladders.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "spelunkery:rope_ladder"
+  ]
+}

--- a/common/src/main/resources/data/c/tags/block/storage_blocks.json
+++ b/common/src/main/resources/data/c/tags/block/storage_blocks.json
@@ -1,0 +1,17 @@
+{
+  "replace": false,
+  "values": [
+    "spelunkery:cinnabar_block",
+    "spelunkery:dust_block",
+    "spelunkery:salt_block",
+    "spelunkery:sulfur_block",
+    "spelunkery:saltpeter_block",
+    "spelunkery:rough_cinnabar_block",
+    "spelunkery:rough_lazurite_block",
+    "spelunkery:rough_emerald_block",
+    "spelunkery:rough_diamond_block",
+    "spelunkery:rough_quartz_block",
+    "spelunkery:rough_magnetite_block",
+    "spelunkery:tangle_roots_block"
+  ]
+}

--- a/common/src/main/resources/data/c/tags/block/storage_blocks.json
+++ b/common/src/main/resources/data/c/tags/block/storage_blocks.json
@@ -11,7 +11,7 @@
     "spelunkery:rough_emerald_block",
     "spelunkery:rough_diamond_block",
     "spelunkery:rough_quartz_block",
-    "spelunkery:rough_magnetite_block",
+    "spelunkery:raw_magnetite_block",
     "spelunkery:tangle_roots_block"
   ]
 }

--- a/common/src/main/resources/data/c/tags/block/storage_blocks/cinnabar.json
+++ b/common/src/main/resources/data/c/tags/block/storage_blocks/cinnabar.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "spelunkery:cinnabar_block"
+  ]
+}

--- a/common/src/main/resources/data/c/tags/block/storage_blocks/quartz.json
+++ b/common/src/main/resources/data/c/tags/block/storage_blocks/quartz.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "spelunkery:rough_quartz_block"
+  ]
+}

--- a/common/src/main/resources/data/c/tags/block/storage_blocks/raw_cinnabar.json
+++ b/common/src/main/resources/data/c/tags/block/storage_blocks/raw_cinnabar.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "spelunkery:rough_cinnabar_block"
+  ]
+}

--- a/common/src/main/resources/data/c/tags/block/storage_blocks/raw_diamond.json
+++ b/common/src/main/resources/data/c/tags/block/storage_blocks/raw_diamond.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "spelunkery:rough_diamond_block"
+  ]
+}

--- a/common/src/main/resources/data/c/tags/block/storage_blocks/raw_emerald.json
+++ b/common/src/main/resources/data/c/tags/block/storage_blocks/raw_emerald.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "spelunkery:rough_emerald_block"
+  ]
+}

--- a/common/src/main/resources/data/c/tags/block/storage_blocks/raw_iron.json
+++ b/common/src/main/resources/data/c/tags/block/storage_blocks/raw_iron.json
@@ -1,6 +1,6 @@
 {
   "replace": false,
   "values": [
-    "spelunkery:rough_magnetite_block"
+    "spelunkery:raw_magnetite_block"
   ]
 }

--- a/common/src/main/resources/data/c/tags/block/storage_blocks/raw_iron.json
+++ b/common/src/main/resources/data/c/tags/block/storage_blocks/raw_iron.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "spelunkery:rough_magnetite_block"
+  ]
+}

--- a/common/src/main/resources/data/c/tags/block/storage_blocks/raw_lapis.json
+++ b/common/src/main/resources/data/c/tags/block/storage_blocks/raw_lapis.json
@@ -1,6 +1,6 @@
 {
   "replace": false,
   "values": [
-    "spelunkery:raw_lazurite_block"
+    "spelunkery:rough_lazurite_block"
   ]
 }

--- a/common/src/main/resources/data/c/tags/block/storage_blocks/raw_lapis.json
+++ b/common/src/main/resources/data/c/tags/block/storage_blocks/raw_lapis.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "spelunkery:rough_lazurite_block"
+  ]
+}

--- a/common/src/main/resources/data/c/tags/block/storage_blocks/salt.json
+++ b/common/src/main/resources/data/c/tags/block/storage_blocks/salt.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "spelunkery:salt_block"
+  ]
+}

--- a/common/src/main/resources/data/c/tags/block/storage_blocks/saltpeter.json
+++ b/common/src/main/resources/data/c/tags/block/storage_blocks/saltpeter.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "spelunkery:saltpeter_block"
+  ]
+}

--- a/common/src/main/resources/data/c/tags/block/storage_blocks/sulfur.json
+++ b/common/src/main/resources/data/c/tags/block/storage_blocks/sulfur.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "spelunkery:sulfur_block"
+  ]
+}

--- a/common/src/main/resources/data/c/tags/item/dusts.json
+++ b/common/src/main/resources/data/c/tags/item/dusts.json
@@ -1,0 +1,9 @@
+{
+  "replace": false,
+  "values": [
+    "spelunkery:dust",
+    "spelunkery:salt",
+    "spelunkery:sulfur",
+    "spelunkery:saltpeter"
+  ]
+}

--- a/common/src/main/resources/data/c/tags/item/dusts/salt.json
+++ b/common/src/main/resources/data/c/tags/item/dusts/salt.json
@@ -1,6 +1,6 @@
 {
   "replace": false,
   "values": [
-    "spelunkery:raw_lazurite_block"
+    "spelunkery:salt"
   ]
 }

--- a/common/src/main/resources/data/c/tags/item/dusts/saltpeter.json
+++ b/common/src/main/resources/data/c/tags/item/dusts/saltpeter.json
@@ -1,6 +1,6 @@
 {
   "replace": false,
   "values": [
-    "spelunkery:raw_lazurite_block"
+    "spelunkery:saltpeter"
   ]
 }

--- a/common/src/main/resources/data/c/tags/item/dusts/sulfur.json
+++ b/common/src/main/resources/data/c/tags/item/dusts/sulfur.json
@@ -1,6 +1,6 @@
 {
   "replace": false,
   "values": [
-    "spelunkery:raw_lazurite_block"
+    "spelunkery:sulfur"
   ]
 }

--- a/common/src/main/resources/data/c/tags/item/raw_materials.json
+++ b/common/src/main/resources/data/c/tags/item/raw_materials.json
@@ -1,0 +1,10 @@
+{
+  "replace": false,
+  "values": [
+    "spelunkery:rough_cinnabar",
+    "spelunkery:rough_lazurite",
+    "spelunkery:rough_emerald",
+    "spelunkery:rough_diamond",
+    "spelunkery:raw_magnetite"
+  ]
+}

--- a/common/src/main/resources/data/c/tags/item/raw_materials/cinnabar.json
+++ b/common/src/main/resources/data/c/tags/item/raw_materials/cinnabar.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "spelunkery:rough_cinnabar"
+  ]
+}

--- a/common/src/main/resources/data/c/tags/item/raw_materials/diamond.json
+++ b/common/src/main/resources/data/c/tags/item/raw_materials/diamond.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "spelunkery:rough_diamond"
+  ]
+}

--- a/common/src/main/resources/data/c/tags/item/raw_materials/emerald.json
+++ b/common/src/main/resources/data/c/tags/item/raw_materials/emerald.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "spelunkery:rough_emerald"
+  ]
+}

--- a/common/src/main/resources/data/c/tags/item/raw_materials/iron.json
+++ b/common/src/main/resources/data/c/tags/item/raw_materials/iron.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "spelunkery:raw_magnetite"
+  ]
+}

--- a/common/src/main/resources/data/c/tags/item/raw_materials/lapis.json
+++ b/common/src/main/resources/data/c/tags/item/raw_materials/lapis.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "spelunkery:rough_lazurite"
+  ]
+}

--- a/common/src/main/resources/data/c/tags/item/storage_blocks.json
+++ b/common/src/main/resources/data/c/tags/item/storage_blocks.json
@@ -1,0 +1,17 @@
+{
+  "replace": false,
+  "values": [
+    "spelunkery:cinnabar_block",
+    "spelunkery:dust_block",
+    "spelunkery:salt_block",
+    "spelunkery:sulfur_block",
+    "spelunkery:saltpeter_block",
+    "spelunkery:rough_cinnabar_block",
+    "spelunkery:rough_lazurite_block",
+    "spelunkery:rough_emerald_block",
+    "spelunkery:rough_diamond_block",
+    "spelunkery:rough_quartz_block",
+    "spelunkery:rough_magnetite_block",
+    "spelunkery:tangle_roots_block"
+  ]
+}

--- a/common/src/main/resources/data/c/tags/item/storage_blocks.json
+++ b/common/src/main/resources/data/c/tags/item/storage_blocks.json
@@ -11,7 +11,7 @@
     "spelunkery:rough_emerald_block",
     "spelunkery:rough_diamond_block",
     "spelunkery:rough_quartz_block",
-    "spelunkery:rough_magnetite_block",
+    "spelunkery:raw_magnetite_block",
     "spelunkery:tangle_roots_block"
   ]
 }

--- a/common/src/main/resources/data/c/tags/item/storage_blocks/cinnabar.json
+++ b/common/src/main/resources/data/c/tags/item/storage_blocks/cinnabar.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "spelunkery:cinnabar_block"
+  ]
+}

--- a/common/src/main/resources/data/c/tags/item/storage_blocks/quartz.json
+++ b/common/src/main/resources/data/c/tags/item/storage_blocks/quartz.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "spelunkery:rough_quartz_block"
+  ]
+}

--- a/common/src/main/resources/data/c/tags/item/storage_blocks/raw_cinnabar.json
+++ b/common/src/main/resources/data/c/tags/item/storage_blocks/raw_cinnabar.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "spelunkery:rough_cinnabar_block"
+  ]
+}

--- a/common/src/main/resources/data/c/tags/item/storage_blocks/raw_diamond.json
+++ b/common/src/main/resources/data/c/tags/item/storage_blocks/raw_diamond.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "spelunkery:rough_diamond_block"
+  ]
+}

--- a/common/src/main/resources/data/c/tags/item/storage_blocks/raw_emerald.json
+++ b/common/src/main/resources/data/c/tags/item/storage_blocks/raw_emerald.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "spelunkery:rough_emerald_block"
+  ]
+}

--- a/common/src/main/resources/data/c/tags/item/storage_blocks/raw_iron.json
+++ b/common/src/main/resources/data/c/tags/item/storage_blocks/raw_iron.json
@@ -1,6 +1,6 @@
 {
   "replace": false,
   "values": [
-    "spelunkery:rough_magnetite_block"
+    "spelunkery:raw_magnetite_block"
   ]
 }

--- a/common/src/main/resources/data/c/tags/item/storage_blocks/raw_iron.json
+++ b/common/src/main/resources/data/c/tags/item/storage_blocks/raw_iron.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "spelunkery:rough_magnetite_block"
+  ]
+}

--- a/common/src/main/resources/data/c/tags/item/storage_blocks/raw_lapis.json
+++ b/common/src/main/resources/data/c/tags/item/storage_blocks/raw_lapis.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "spelunkery:rough_lazurite_block"
+  ]
+}

--- a/common/src/main/resources/data/c/tags/item/storage_blocks/salt.json
+++ b/common/src/main/resources/data/c/tags/item/storage_blocks/salt.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "spelunkery:salt_block"
+  ]
+}

--- a/common/src/main/resources/data/c/tags/item/storage_blocks/saltpeter.json
+++ b/common/src/main/resources/data/c/tags/item/storage_blocks/saltpeter.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "spelunkery:saltpeter_block"
+  ]
+}

--- a/common/src/main/resources/data/c/tags/item/storage_blocks/sulfur.json
+++ b/common/src/main/resources/data/c/tags/item/storage_blocks/sulfur.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "spelunkery:sulfur_block"
+  ]
+}

--- a/common/src/main/resources/data/minecraft/tags/block/slabs.json
+++ b/common/src/main/resources/data/minecraft/tags/block/slabs.json
@@ -1,0 +1,11 @@
+{
+  "replace": false,
+  "values": [
+    "spelunkery:rock_salt_slab",
+    "spelunkery:polished_rock_salt_slab",
+    "spelunkery:rock_salt_brick_slab",
+    "spelunkery:nephrite_slab",
+    "spelunkery:polished_nephrite_slab",
+    "spelunkery:polished_nephrite_brick_slab"
+  ]
+}

--- a/common/src/main/resources/data/minecraft/tags/block/stairs.json
+++ b/common/src/main/resources/data/minecraft/tags/block/stairs.json
@@ -1,0 +1,11 @@
+{
+  "replace": false,
+  "values": [
+    "spelunkery:rock_salt_stairs",
+    "spelunkery:polished_rock_salt_stairs",
+    "spelunkery:rock_salt_brick_stairs",
+    "spelunkery:nephrite_stairs",
+    "spelunkery:polished_nephrite_stairs",
+    "spelunkery:polished_nephrite_brick_stairs"
+  ]
+}

--- a/common/src/main/resources/data/minecraft/tags/item/slabs.json
+++ b/common/src/main/resources/data/minecraft/tags/item/slabs.json
@@ -1,0 +1,11 @@
+{
+  "replace": false,
+  "values": [
+    "spelunkery:rock_salt_slab",
+    "spelunkery:polished_rock_salt_slab",
+    "spelunkery:rock_salt_brick_slab",
+    "spelunkery:nephrite_slab",
+    "spelunkery:polished_nephrite_slab",
+    "spelunkery:polished_nephrite_brick_slab"
+  ]
+}

--- a/common/src/main/resources/data/minecraft/tags/item/stairs.json
+++ b/common/src/main/resources/data/minecraft/tags/item/stairs.json
@@ -1,0 +1,11 @@
+{
+  "replace": false,
+  "values": [
+    "spelunkery:rock_salt_stairs",
+    "spelunkery:polished_rock_salt_stairs",
+    "spelunkery:rock_salt_brick_stairs",
+    "spelunkery:nephrite_stairs",
+    "spelunkery:polished_nephrite_stairs",
+    "spelunkery:polished_nephrite_brick_stairs"
+  ]
+}

--- a/common/src/main/resources/data/minecraft/tags/item/walls.json
+++ b/common/src/main/resources/data/minecraft/tags/item/walls.json
@@ -1,0 +1,11 @@
+{
+  "replace": false,
+  "values": [
+    "spelunkery:rock_salt_wall",
+    "spelunkery:polished_rock_salt_wall",
+    "spelunkery:rock_salt_brick_wall",
+    "spelunkery:nephrite_wall",
+    "spelunkery:polished_nephrite_wall",
+    "spelunkery:polished_nephrite_brick_wall"
+  ]
+}


### PR DESCRIPTION
More specifically, this:

- Adds stairs and slabs to the relevant minecraft tags
- Adds walls to the relevant item tag
- Adds compressed blocks to the relevant common storage block tags
- Adds rough items to the relevant raw material common tags
- Adds dusts to common dust tags